### PR TITLE
Add additional parameter to authorizeUrl.

### DIFF
--- a/Web/Authenticate/OAuth.hs
+++ b/Web/Authenticate/OAuth.hs
@@ -159,9 +159,10 @@ authorizeUrl :: OAuth           -- ^ OAuth Application
              -> Credential      -- ^ Temporary Credential (Request Token & Secret)
              -> String          -- ^ URL to authorize
 authorizeUrl oa cr = oauthAuthorizeUri oa ++ BS.unpack (renderSimpleQuery True queries)
-  where queries = case oauthCallback oa of
-                    Nothing       -> [("oauth_token", token cr)]
-                    Just callback -> [("oauth_token", token cr), ("oauth_callback", callback)]
+  where fixed = [ ("oauth_token", token cr), ("oauth_consumer_key", oauthConsumerKey oa)]
+        queries = case oauthCallback oa of
+                    Nothing       -> fixed
+                    Just callback -> ("oauth_callback", callback):fixed
 
 -- | Get Access token.
 getAccessToken, getTokenCredential


### PR DESCRIPTION
This is needed to comply with the Netflix api.

I can neither confirm nor deny if this will behave with other OAuth apis.
