### PR TITLE
Support Heimdal Kerberos.

### DIFF
--- a/authenticate-kerberos/Setup.lhs
+++ b/authenticate-kerberos/Setup.lhs
@@ -2,6 +2,42 @@
 
 > module Main where
 > import Distribution.Simple
+> import System.Process (readProcessWithExitCode)
+> import System.Exit (ExitCode(..))
+> import System.Directory (removeFile)
+> import System.IO.Error (try)
 
 > main :: IO ()
-> main = defaultMain
+> main = defaultMainWithHooks simpleUserHooks'
+>  where
+>    simpleUserHooks' = simpleUserHooks
+>      { postConf = postConf'
+>      , postClean = postClean'
+>      }
+>
+>    postConf' x configFlags desc y = do
+>      hconf <- checkHeimKinit
+>      writeFile "config.h" $ concat
+>          [ "#ifndef CONFIG_H\n"
+>          , "#define CONFIG_H\n"
+>          , "\n"
+>          , "/* Define to 1 if you have Heimdal Kerberos. */\n"
+>          , hconf
+>          , "\n\n"
+>          , "#endif\n"
+>          ]
+>      let configFlags' = updateConfigFlags configFlags
+>      postConf simpleUserHooks x configFlags' desc y
+>      where
+>        updateConfigFlags configFlags = configFlags
+>
+>    postClean' _ _ _ _ = do
+>      try . removeFile $ "config.h"
+>      return ()
+>
+> checkHeimKinit :: IO String
+> checkHeimKinit = do
+>    (e,_,_) <- readProcessWithExitCode "kinit" ["--version"] ""
+>    if e == ExitSuccess then
+>        return "#define HAVE_HEIMDAL 1"
+>        else return "/* #undef HAVE_HEIMDAL */"

--- a/authenticate-kerberos/Web/Authenticate/Kerberos.hs
+++ b/authenticate-kerberos/Web/Authenticate/Kerberos.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
+#include "../../config.h"
 -- | Module for using a kerberos authentication service.
 --
 -- Please note that all configuration should have been done
@@ -65,7 +67,11 @@ loginKerberos username password = do
     fetch :: IO KerberosAuthResult
     fetch = do
       (exitCode, _out, err) <- readProcessWithExitCode
+#ifdef HAVE_HEIMDAL
+          "kinit" ["--password-file=STDIN", T.unpack username] (T.unpack password)
+#else
           "kinit" [T.unpack username] (T.unpack password)
+#endif
       case exitCode of
         ExitSuccess   -> return Ok
         ExitFailure x -> return $ interpretError x (T.pack err)

--- a/authenticate-kerberos/authenticate-kerberos.cabal
+++ b/authenticate-kerberos/authenticate-kerberos.cabal
@@ -9,7 +9,7 @@ description:     Kerberos authenticate.
 category:        Web
 stability:       Stable
 cabal-version:   >= 1.6
-build-type:      Simple
+build-type:      Custom
 homepage:        http://github.com/yesodweb/authenticate
 
 library


### PR DESCRIPTION
This change allows authenticate-kerberos to work with Heimdal Kerberos, which is found on Mac OS X, various BSDs, and some Linux distros. It will default to the MIT Kerberos implementation.

Regards,
Aaron
