### PR TITLE
Relax http-types dependency

### DIFF
--- a/authenticate-oauth/authenticate-oauth.cabal
+++ b/authenticate-oauth/authenticate-oauth.cabal
@@ -1,4 +1,3 @@
-
 name:            authenticate-oauth
 version:         1.4.0.4
 license:         BSD3
@@ -25,7 +24,7 @@ library
                    , base64-bytestring             >= 0.1      && < 1.1
                    , SHA                           >= 1.4      && < 1.7
                    , random
-                   , http-types                    >= 0.6      && < 0.8
+                   , http-types                    >= 0.6
                    , blaze-builder
                    , conduit                       >= 0.4      && < 0.6
                    , resourcet                     >= 0.3      && < 0.5


### PR DESCRIPTION
A lot of other package have removed the upper bound on http-types; this does the same here.  An upload to hackage would be appreciated. (Please only apply after travis looked at it, I did not test this change.)
