### PR TITLE
authenticate-oauth.cabal: allow RSA-2

### DIFF
--- a/authenticate-oauth/Web/Authenticate/OAuth.hs
+++ b/authenticate-oauth/Web/Authenticate/OAuth.hs
@@ -21,7 +21,7 @@ module Web.Authenticate.OAuth
       paramEncode, addScope, addMaybeProxy
     ) where
 import           Blaze.ByteString.Builder     (toByteString, Builder)
-import           Codec.Crypto.RSA             (ha_SHA1, rsassa_pkcs1_v1_5_sign)
+import qualified Codec.Crypto.RSA             as RSA
 import           Control.Exception
 import           Control.Monad
 import           Control.Monad.IO.Class       (MonadIO, liftIO)
@@ -346,7 +346,13 @@ genSign oa tok req =
     PLAINTEXT ->
       return $ BS.intercalate "&" $ map paramEncode [oauthConsumerSecret oa, tokenSecret tok]
     RSASHA1 pr ->
-      liftM (encode . toStrict . rsassa_pkcs1_v1_5_sign ha_SHA1 pr) (getBaseString tok req)
+      liftM (encode . toStrict . RSA.rsassa_pkcs1_v1_5_sign
+#if MIN_VERSION_RSA(2, 0, 0)
+                                     RSA.hashSHA1
+#else
+                                     RSA.ha_SHA1
+#endif
+                                     pr) (getBaseString tok req)
 
 #if MIN_VERSION_http_conduit(2, 0, 0)
 addAuthHeader :: BS.ByteString -> Credential -> Request -> Request

--- a/authenticate-oauth/authenticate-oauth.cabal
+++ b/authenticate-oauth/authenticate-oauth.cabal
@@ -19,7 +19,7 @@ library
                    , transformers                  >= 0.1      && < 0.4
                    , bytestring                    >= 0.9
                    , crypto-pubkey-types           >= 0.1      && < 0.5
-                   , RSA                           >= 1.2      && < 1.3
+                   , RSA                           >= 1.2      && < 2.1
                    , time
                    , data-default
                    , base64-bytestring             >= 0.1      && < 1.1


### PR DESCRIPTION
The only cosmetic change is rename of 'ha_SHA1' to 'hashSHA1'

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
