### PR TITLE
Strip openid url submitted by user

### DIFF
--- a/authenticate/Web/Authenticate/OpenId.hs
+++ b/authenticate/Web/Authenticate/OpenId.hs
@@ -49,7 +49,7 @@ getForwardUrl
     -> m Text -- ^ URL to send the user to.
 getForwardUrl openid' complete mrealm params manager = do
     let realm = fromMaybe complete mrealm
-    claimed <- normalize openid'
+    claimed <- normalize $ T.strip openid'
     disc <- discover claimed manager
     let helper s q = return $ T.concat
             [ s


### PR DESCRIPTION
The problem is described in https://github.com/yesodweb/yesod/issues/794

> When trying to log in using openid url which has trailing/preceding whitespace (e.g. "http://openid.example.com/username ", it fails with login error message NormalizationException "http://openid.example.com/user ".
