### PR TITLE
Allow RSA-2.1

### DIFF
--- a/authenticate-oauth/authenticate-oauth.cabal
+++ b/authenticate-oauth/authenticate-oauth.cabal
@@ -19,7 +19,7 @@ library
                    , transformers                  >= 0.1      && < 0.5
                    , bytestring                    >= 0.9
                    , crypto-pubkey-types           >= 0.1      && < 0.5
-                   , RSA                           == 2.0.*
+                   , RSA                           >= 2.0      && < 2.2
                    , time
                    , data-default
                    , base64-bytestring             >= 0.1      && < 1.1


### PR DESCRIPTION
Looks like authenticate-oauth works fine with RSA-2.1.