### PR TITLE
Add oauth_body_hash extension and check signature

### DIFF
--- a/authenticate-oauth/Web/Authenticate/OAuth.hs
+++ b/authenticate-oauth/Web/Authenticate/OAuth.hs
@@ -39,6 +39,10 @@ module Web.Authenticate.OAuth
 
 import           Blaze.ByteString.Builder     (toByteString)
 import           Control.Exception
+#if MIN_VERSION_base(4,8,0)
+#else
+import           Control.Applicative          ((<*>),(<$>))
+#endif
 import           Control.Arrow                (second)
 import           Control.Monad
 import           Control.Monad.IO.Class       (MonadIO, liftIO)

--- a/authenticate-oauth/Web/Authenticate/OAuth.hs
+++ b/authenticate-oauth/Web/Authenticate/OAuth.hs
@@ -341,15 +341,10 @@ checkOAuthB :: MonadIO m => OAuth -> Credential -> Request -> m (Either OAuthExc
 checkOAuthB oa crd req0 = do
   (mosig, reqBody) <- getSig <$> loadBodyBS req0
   let req = req0 {requestBody = RequestBodyBS reqBody}
-  liftIO $ print reqBody
-  liftIO $ print mosig
   case mosig of
     "" -> return . Left $ OAuthException "oauth_signature parameter not found"
     osig -> do
-          let tok = injectOAuthToCred oa crd
-          nsig <- genSign oa tok req
-          liftIO $ print $ paramEncode nsig
-          liftIO $ print nsig
+          nsig <- genSign oa crd req
           return $ if osig == paramEncode nsig
                           then Right req0
                           else Left $ OAuthException "Failed test of oauth_signature"

--- a/authenticate-oauth/authenticate-oauth.cabal
+++ b/authenticate-oauth/authenticate-oauth.cabal
@@ -27,6 +27,7 @@ library
                    , random
                    , http-types                    >= 0.6
                    , blaze-builder
+                   , transformers-compat           >= 0.3
     exposed-modules: Web.Authenticate.OAuth, Web.Authenticate.OAuth.IO
     ghc-options:     -Wall
 

--- a/authenticate-oauth/authenticate-oauth.cabal
+++ b/authenticate-oauth/authenticate-oauth.cabal
@@ -1,5 +1,5 @@
 name:            authenticate-oauth
-version:         1.5.1.1
+version:         1.5.2
 license:         BSD3
 license-file:    LICENSE
 author:          Hiromi Ishii


### PR DESCRIPTION
I am working on an [LTI 1.1](https://www.imsglobal.org/specs/ltiv1p1/implementation-guide) service provider (for edX). It uses oauth 1.0 protocol with [oauth_body_hash extension](https://oauth.googlecode.com/svn/spec/ext/body_hash/1.0/oauth-bodyhash.html). A service provider also behaves as both - a client and a server in OAuth scheme. Therefore I need to add two things: oauth_body_hash extension and a function to verify incoming requests.
In this pull request I have mainly changed two things:
    1) The extension is backwards compatible with original oauth 1.0, so I have modified function `signOAuth`.
    2) I have added `checkOAuth` function that verifies existing requests.

Though I have tested the code in my project (LTI service), the solution is quite dirty and requires further testing.