### PR TITLE
Allow transformers-0.6 series

### DIFF
--- a/authenticate-oauth/authenticate-oauth.cabal
+++ b/authenticate-oauth/authenticate-oauth.cabal
@@ -17,7 +17,7 @@ library
     default-language: Haskell2010
     build-depends:   base                          >= 4.10     && < 5
                    , http-client                   >= 0.3
-                   , transformers                  >= 0.1      && < 0.6
+                   , transformers                  >= 0.1      && < 0.7
                    , bytestring                    >= 0.9
                    , crypto-pubkey-types           >= 0.1      && < 0.5
                    , RSA                           >= 2.0      && < 2.5


### PR DESCRIPTION
Tested using

    cabal build --constraint='mtl>=2.3' --constraint='transformers>=0.6' -w ghc-9.2.3
