### PR TITLE
hardcode body hash as sha256

### DIFF
--- a/authenticate-oauth/Web/Authenticate/OAuth.hs
+++ b/authenticate-oauth/Web/Authenticate/OAuth.hs
@@ -278,7 +278,8 @@ signOAuth' oa crd withHash add_auth req = do
              . encode
              . BSL.toStrict
              . bytestringDigest
-             . sha1
+             -- TODO specify as a function parameter
+             . sha256
              . BSL.fromStrict) `liftM` loadBodyBS req
     -- encodeHash (Just h) = "oauth_body_hash=\"" `BS.append` paramEncode h `BS.append` "\","
     -- encodeHash Nothing  = ""


### PR DESCRIPTION
The Mastercard API requires the body hash algorithm be sha256. Hardcoding for now while we wire the rest up in MWB. Will return later to pass the hash algorithm in as a function parameter and submit a PR upstream as well.