### PR TITLE
Add support for aeson 2.2

### DIFF
--- a/authenticate/Web/Authenticate/BrowserId.hs
+++ b/authenticate/Web/Authenticate/BrowserId.hs
@@ -8,7 +8,12 @@ module Web.Authenticate.BrowserId
 
 import Data.Text (Text)
 import Network.HTTP.Conduit (parseUrlThrow, responseBody, httpLbs, Manager, method, urlEncodedBody)
+#if MIN_VERSION_aeson(2,2,0)
+import Data.Aeson (Value (Object, String))
+import Data.Aeson.Parser (json)
+#else
 import Data.Aeson (json, Value (Object, String))
+#endif
 import Data.Attoparsec.Lazy (parse, maybeResult)
 #if MIN_VERSION_aeson(2,0,0)
 import qualified Data.Aeson.KeyMap as Map

--- a/authenticate/Web/Authenticate/Rpxnow.hs
+++ b/authenticate/Web/Authenticate/Rpxnow.hs
@@ -22,6 +22,9 @@ module Web.Authenticate.Rpxnow
     ) where
 
 import Data.Aeson
+#if MIN_VERSION_aeson(2,2,0)
+import Data.Aeson.Parser (json)
+#endif
 import Network.HTTP.Conduit
 import Control.Monad.IO.Class
 import Data.Maybe

--- a/authenticate/authenticate.cabal
+++ b/authenticate/authenticate.cabal
@@ -21,6 +21,7 @@ library
     default-language: Haskell2010
     build-depends:   base                          >= 4.10     && < 5
                    , aeson                         >= 0.5
+                   , attoparsec-aeson              >= 2.1
                    , http-conduit                  >= 1.5
                    , transformers                  >= 0.1
                    , bytestring                    >= 0.9

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,5 +5,5 @@ packages:
 - authenticate-oauth/
 
 extra-deps:
-- base64-bytestring-1.2.0.0
+- base64-bytestring-1.2.1.0
 - attoparsec-aeson-2.1.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,3 +6,4 @@ packages:
 
 extra-deps:
 - base64-bytestring-1.2.0.0
+- attoparsec-aeson-2.1.0.0


### PR DESCRIPTION
The 'json' functionality has been moved to `attoparsec-aeson`, into the module Data.Aeson.Parser with aeson 2.2